### PR TITLE
feat:use async for a file's execute method

### DIFF
--- a/src/VaunchApp.vue
+++ b/src/VaunchApp.vue
@@ -55,7 +55,9 @@ const executeCommand = (commandArgs: string[], newTab = false) => {
   // Check if we're running a command, if we find it in commands, execute it
   for (let command of commands) {
     if (command.getNames().includes(operator)) {
-      return handleResponse(command.execute(commandArgs));
+      return command.execute(commandArgs).then(response => {
+        handleResponse(response);
+      })
     }
   }
 
@@ -63,9 +65,10 @@ const executeCommand = (commandArgs: string[], newTab = false) => {
   if (fuzzyFiles.items.length > 0 && config.fuzzy) {
     // Also shift this entry off the history, in case it was a qry file
     sessionConfig.history.shift();
-    let response =
-      fuzzyFiles.items[fuzzyFiles.index].execute(commandArgs);
-    return handleResponse(response);
+    const fuzzyFile = fuzzyFiles.items[fuzzyFiles.index];
+    return fuzzyFile.execute(commandArgs).then((response) => {
+      handleResponse(response);
+    })
   }
 
   // If ctrl was held, append _black to commandArgs
@@ -78,14 +81,18 @@ const executeCommand = (commandArgs: string[], newTab = false) => {
     // it into the commandArgs. This deals with a multi ${} file, executed like:
     // prefix:firstArg secondArg
     if (operator.split(":")[1]) commandArgs.unshift(operator.split(":")[1]);
-    return handleResponse(file.execute(commandArgs));
+    return file.execute(commandArgs).then((response) => {
+      return handleResponse(response);
+    })
   }
 
   // If no command was found, let's check if we're running a file
   if (operator.includes("/")) {
     let file: VaunchFile = folders.getFileByPath(operator);
     if (file) {
-      return handleResponse(file.execute(commandArgs));
+      return file.execute(commandArgs).then((response) => {
+        return handleResponse(response);
+      })
     }
   }
 
@@ -109,7 +116,9 @@ const executeCommand = (commandArgs: string[], newTab = false) => {
     }
     // If a default file was found, execute it with the commandArgs, returning the response to vaunchInput
     if (file) {
-      return handleResponse(file.execute(commandArgs));
+      return file.execute(commandArgs).then((response) => {
+        handleResponse(response);
+      });
     }
   }
   // If everything fails, i.e no default search, just clear the input

--- a/src/components/VaunchAppOption.vue
+++ b/src/components/VaunchAppOption.vue
@@ -55,19 +55,21 @@ const setWindow = (window: string, show: boolean) => {
 
 const exportVaunch = () => {
   let vaunchExport = new VaunchExport();
-  let response: VaunchResponse = vaunchExport.execute([]);
-  if (response.type != ResponseType.Success) {
-    handleResponse(response);
-  }
+  vaunchExport.execute([]).then((response) => {
+    if (response.type != ResponseType.Success) {
+      handleResponse(response);
+    }
+  })
   setWindow("", false);
 }
 
 const importVaunch = () => {
   let vaunchImport = new VaunchImport();
-  let response: VaunchResponse = vaunchImport.execute([]);
-  if (response.type != ResponseType.Success) {
-    handleResponse(response);
-  }
+  vaunchImport.execute([]).then((response) => {
+    if (response.type != ResponseType.Success) {
+      handleResponse(response);
+    }
+  })
   setWindow("", false);
 }
 </script>

--- a/src/components/VaunchFileAdd.vue
+++ b/src/components/VaunchFileAdd.vue
@@ -43,7 +43,7 @@ function missingFieldResponse(fields:string[]) {
   })
 }
 
-const createFile = () => {
+const createFile = async () => {
 
   // Ensure required fields are set
   let missingFields:string[] = [];
@@ -63,11 +63,11 @@ const createFile = () => {
   let filePath = `${props.folder.name}/${fileName}`
   let content:string = newContent.value.value
   if (state.fileType == "lnk") {
-    let response:VaunchResponse = touch.execute([filePath, content])
+    let response:VaunchResponse = await touch.execute([filePath, content])
     if (response.type == ResponseType.Error) return handleResponse(response);
   } else if (state.fileType == "qry") {
     let prefix:string = newPrefix.value.value
-    let response:VaunchResponse = touch.execute([filePath, prefix, content])
+    let response:VaunchResponse = await touch.execute([filePath, prefix, content])
     if (response.type == ResponseType.Error) return handleResponse(response);
   }
 
@@ -75,21 +75,21 @@ const createFile = () => {
   // Edit the icon of the file
   if (newIcon.value.value != "" || newIconClass.value.value != "" ) {
     let setIcon = new VaunchSetIcon();
-    let response: VaunchResponse = setIcon.execute([filePath, newIcon.value.value.toLowerCase(), newIconClass.value.value.toLowerCase()])
+    let response: VaunchResponse = await setIcon.execute([filePath, newIcon.value.value.toLowerCase(), newIconClass.value.value.toLowerCase()])
     if (response.type == ResponseType.Error) return handleResponse(response);
   }
 
   // Edit the description of the file
   if (newDescription.value.value != "") {
     let setDesc = new VaunchSetDescription();
-    let response: VaunchResponse = setDesc.execute([filePath, newDescription.value.value])
+    let response: VaunchResponse = await setDesc.execute([filePath, newDescription.value.value])
     if (response.type == ResponseType.Error) return handleResponse(response);
   }
 
   // If the file position is set, run set-pos
   if (newPos.value.value) {
     let setPos = new VaunchSetPosition();
-    let response: VaunchResponse = setPos.execute([filePath, newPos.value.value.toLowerCase()])
+    let response: VaunchResponse = await setPos.execute([filePath, newPos.value.value.toLowerCase()])
     if (response.type == ResponseType.Error) return handleResponse(response);
   }
 

--- a/src/components/VaunchFileEdit.vue
+++ b/src/components/VaunchFileEdit.vue
@@ -29,7 +29,7 @@ const closeWindow = () => {
   emit('closeEdit');
 }
 
-const saveFile = () => {
+const saveFile = async () => {
   // .value.value is used here to get the .value of the reference,
   // a HTMLInputElement, which itself has a .value property
 
@@ -49,28 +49,28 @@ const saveFile = () => {
   if (editArgs.length > 0) {
     // Edit the file, using the originalPath to get to the file
     let edit = new VaunchEditFile();
-    let response: VaunchResponse = edit.execute([originalPath, ...editArgs]);
+    let response: VaunchResponse = await edit.execute([originalPath, ...editArgs]);
     if (response.type == ResponseType.Error) return handleResponse(response);
   }
 
   // Edit the icon of the file
   if (newIcon.value.value != props.file.icon || newIconClass.value.value != props.file.iconClass) {
     let setIcon = new VaunchSetIcon();
-    let response: VaunchResponse = setIcon.execute([originalPath, newIcon.value.value.toLowerCase(), newIconClass.value.value.toLowerCase()])
+    let response: VaunchResponse = await setIcon.execute([originalPath, newIcon.value.value.toLowerCase(), newIconClass.value.value.toLowerCase()])
     if (response.type == ResponseType.Error) return handleResponse(response);
   }
 
   // Edit the description of the file
   if (newDescription.value.value != props.file.description) {
     let setDesc = new VaunchSetDescription();
-    let response: VaunchResponse = setDesc.execute([originalPath, newDescription.value.value])
+    let response: VaunchResponse = await setDesc.execute([originalPath, newDescription.value.value])
     if (response.type == ResponseType.Error) return handleResponse(response);
   }
 
   // If the file position has changed, run set-pos
   if (newPos.value.value != props.file.position) {
     let setPos = new VaunchSetPosition();
-    let response: VaunchResponse = setPos.execute([originalPath, newPos.value.value.toLowerCase()])
+    let response: VaunchResponse = await setPos.execute([originalPath, newPos.value.value.toLowerCase()])
     if (response.type == ResponseType.Error) return handleResponse(response);
   }
 
@@ -85,7 +85,7 @@ const saveFile = () => {
                                                           .replace(/\s+/g, '_');
     let newPath = `${newFolderName}/${newFileName}`
     let mv = new VaunchMv();
-    let response: VaunchResponse = mv.execute([originalPath, newPath]);
+    let response: VaunchResponse = await mv.execute([originalPath, newPath]);
     if (response.type == ResponseType.Error) return handleResponse(response);
   }
 

--- a/src/components/VaunchFolderEdit.vue
+++ b/src/components/VaunchFolderEdit.vue
@@ -24,25 +24,25 @@ const closeWindow = () => {
   emit('closeEdit');
 }
 
-const createFolder = () => {
+const createFolder = async () => {
   // Create the folder
   let mkdir = new VaunchMkdir();
 
   let newFolderName = (newName.value.value as string).toLowerCase()
                                                      .replace(/\s+/g, '_');
-  let response:VaunchResponse = mkdir.execute([newFolderName])
+  let response:VaunchResponse = await mkdir.execute([newFolderName])
   if (response.type == ResponseType.Error) return handleResponse(response);
 
   // Set the folder icon
   let setIcon = new VaunchSetIcon();
-  response = setIcon.execute([newFolderName, newIcon.value.value, newIconClass.value.value])
+  response = await setIcon.execute([newFolderName, newIcon.value.value, newIconClass.value.value])
   if (response.type == ResponseType.Error) return handleResponse(response);
 
   
   // If the folder position is set, run set-pos
   if (newPos.value.value) {
     let setPos = new VaunchSetPosition();
-    let response: VaunchResponse = setPos.execute([newFolderName, newPos.value.value.toLowerCase()])
+    let response: VaunchResponse = await setPos.execute([newFolderName, newPos.value.value.toLowerCase()])
     if (response.type == ResponseType.Error) return handleResponse(response);
   }
 
@@ -51,7 +51,7 @@ const createFolder = () => {
   closeWindow();
 }
 
-const updateFolder = () => {
+const updateFolder = async () => {
   // .value.value is used here to get the .value of the reference,
   // a HTMLInputElement, which itself has a .value property
   let folderPath:string = props.folder.name;
@@ -59,14 +59,14 @@ const updateFolder = () => {
   // Edit the icon of the folder
   if (newIcon.value.value != props.folder.icon || newIconClass.value.value != props.folder.iconClass) {
     let setIcon = new VaunchSetIcon();
-    let response: VaunchResponse = setIcon.execute([folderPath, newIcon.value.value.toLowerCase(), newIconClass.value.value.toLowerCase()])
+    let response: VaunchResponse = await setIcon.execute([folderPath, newIcon.value.value.toLowerCase(), newIconClass.value.value.toLowerCase()])
     if (response.type == ResponseType.Error) return handleResponse(response);
   }
   
   // If the folder position has changed, run set-pos
   if (newPos.value.value != props.folder.position) {
     let setPos = new VaunchSetPosition();
-    let response: VaunchResponse = setPos.execute([folderPath, newPos.value.value.toLowerCase()])
+    let response: VaunchResponse = await setPos.execute([folderPath, newPos.value.value.toLowerCase()])
     if (response.type == ResponseType.Error) return handleResponse(response);
   }
 
@@ -76,7 +76,7 @@ const updateFolder = () => {
     let newFolderName = (newName.value.value as string).toLowerCase()
                                                     .replace(/\s+/g, '_');
     let mv = new VaunchMv();
-    let response: VaunchResponse = mv.execute([folderPath, newFolderName]);
+    let response: VaunchResponse = await mv.execute([folderPath, newFolderName]);
     if (response.type == ResponseType.Error) return handleResponse(response);
   }
   // Once all edits are made, close the window

--- a/src/components/VaunchGuiCommand.vue
+++ b/src/components/VaunchGuiCommand.vue
@@ -16,8 +16,9 @@ const commandInputBox = ref();
 const hasArgs = props.file.hasArgs();
 
 const execute = (file:VaunchCommand, args:string[]) => {
-  let response = file.execute(args);
-  handleResponse(response);
+  file.execute(args).then((response) => {
+    handleResponse(response);
+  })
   // Clear the input for this command after executing
   if (hasArgs) {
     (commandInputBox.value as HTMLInputElement).value = "";

--- a/src/components/VaunchGuiFile.vue
+++ b/src/components/VaunchGuiFile.vue
@@ -12,11 +12,12 @@ const props = defineProps(["file", "isFuzzy"])
 const emit = defineEmits(["showFileOption"]);
 
 const execute = (file: VaunchUrlFile, args: string[]) => {
-  let response: VaunchResponse = file.execute(args);
-  if (response.type == ResponseType.UpdateInput) {
-    sessionConfig.vaunchInput = response.message;
-    focusVaunchInput();
-  }
+  file.execute(args).then((response) => {
+    if (response.type == ResponseType.UpdateInput) {
+      sessionConfig.vaunchInput = response.message;
+      focusVaunchInput();
+    }
+  })
 }
 
 const toggleOptions = (event: any) => {

--- a/src/models/VaunchCommand.ts
+++ b/src/models/VaunchCommand.ts
@@ -20,7 +20,7 @@ export abstract class VaunchCommand extends VaunchFile {
     return this.manual.parameters.length > 0;
   }
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     return this.makeResponse(ResponseType.Success, "");
   }
   getBaseName(): string {

--- a/src/models/VaunchFile.ts
+++ b/src/models/VaunchFile.ts
@@ -55,7 +55,7 @@ export abstract class VaunchFile {
 
   // Abstract execution method, to be implemented by concrete classes
   // to define what happens when they are ran
-  abstract execute(args: string[]): VaunchResponse;
+  abstract execute(args: string[]): Promise<VaunchResponse>;
 
   makeResponse(type: ResponseType, message: string) {
     // Creates a VaunchResponse for this file, given a ResponseType and a message string

--- a/src/models/VaunchLink.ts
+++ b/src/models/VaunchLink.ts
@@ -34,7 +34,7 @@ export class VaunchLink extends VaunchUrlFile {
     return "Navigate to: " + this.trimString(this.getCorrectURL());
   }
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     // Ensure file content is "linkable"
     const linkUrl: URL | undefined = this.createUrl();
     if (linkUrl) {

--- a/src/models/VaunchQuery.ts
+++ b/src/models/VaunchQuery.ts
@@ -35,7 +35,7 @@ export class VaunchQuery extends VaunchUrlFile {
     return [this.fileName, this.prefix, ...this.aliases];
   }
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     // If no args are provided or ctrl clicking on the file, return the file's prefix
     if (args.length == 0 || args[0] == "_blank" || args[0] == "") {
       return this.makeResponse(ResponseType.UpdateInput, `${this.prefix}: `);

--- a/src/models/commands/config/VaunchExport.ts
+++ b/src/models/commands/config/VaunchExport.ts
@@ -59,7 +59,7 @@ export class VaunchExport extends VaunchCommand {
   }
   description = "Exports vaunch to a file";
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     const config = useConfigStore();
     const folders = useFolderStore();
 

--- a/src/models/commands/config/VaunchFeh.ts
+++ b/src/models/commands/config/VaunchFeh.ts
@@ -33,7 +33,7 @@ export class VaunchFeh extends VaunchCommand {
   aliases: string[] = ["set-bg", "set-background"];
   description = "Changes the background";
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     const config = useConfigStore();
     let background: string = args[0];
     let newBackgroundString: string = background;

--- a/src/models/commands/config/VaunchHelp.ts
+++ b/src/models/commands/config/VaunchHelp.ts
@@ -32,7 +32,7 @@ export class VaunchHelp extends VaunchCommand {
   aliases: string[] = ["show-help", "man"];
   description = "Shows the help window for all Vaunch commands";
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     const sessionConfig = useSessionStore();
     if (args[0]) {
       sessionConfig.helpCommand = args[0];

--- a/src/models/commands/config/VaunchImport.ts
+++ b/src/models/commands/config/VaunchImport.ts
@@ -79,7 +79,7 @@ export class VaunchImport extends VaunchCommand {
   }
   description = "Imports vaunch from a file";
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     const importElem = document.createElement("input");
     importElem.type = "file";
     importElem.click();

--- a/src/models/commands/config/VaunchSetDefaultSearch.ts
+++ b/src/models/commands/config/VaunchSetDefaultSearch.ts
@@ -38,7 +38,7 @@ export class VaunchSetDefaultSearch extends VaunchCommand {
   }
   description = "Sets the default Query file to execute";
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     const config = useConfigStore();
     let newQueryName = "none";
     if (!args[0] || args[0] == "none") {

--- a/src/models/commands/config/VaunchToggleCase.ts
+++ b/src/models/commands/config/VaunchToggleCase.ts
@@ -20,7 +20,7 @@ export class VaunchToggleCase extends VaunchCommand {
   }
   description = "Toggles if names are converted to Title Case";
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     const config = useConfigStore();
     config.titleCase = !config.titleCase;
     return this.makeResponse(

--- a/src/models/commands/config/VaunchToggleCommands.ts
+++ b/src/models/commands/config/VaunchToggleCommands.ts
@@ -20,7 +20,7 @@ export class VaunchToggleCommands extends VaunchCommand {
   }
   description = "Toggles if the commands window is visible";
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     const config = useConfigStore();
     config.showCommands = !config.showCommands;
     return this.makeResponse(

--- a/src/models/commands/config/VaunchToggleFuzzy.ts
+++ b/src/models/commands/config/VaunchToggleFuzzy.ts
@@ -21,7 +21,7 @@ export class VaunchToggleFuzzy extends VaunchCommand {
   }
   description = "Toggles if fuzzy search is enabled";
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     const config = useConfigStore();
     config.fuzzy = !config.fuzzy;
     return this.makeResponse(

--- a/src/models/commands/config/VaunchToggleGui.ts
+++ b/src/models/commands/config/VaunchToggleGui.ts
@@ -19,7 +19,7 @@ export class VaunchToggleGui extends VaunchCommand {
   }
   description = "Toggles if Folders/Commands are visible";
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     const config = useConfigStore();
     config.showGUI = !config.showGUI;
     return this.makeResponse(

--- a/src/models/commands/config/VaunchsetColor.ts
+++ b/src/models/commands/config/VaunchsetColor.ts
@@ -141,7 +141,7 @@ export class VaunchSetColor extends VaunchCommand {
     return `hsla(${hsl[0]},${hsl[1]}%,${hsl[2]}%, 0.75)`;
   }
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     const config = useConfigStore();
     const newWindowColor = args[0];
     const newTextColor = args[1];

--- a/src/models/commands/fs/VaunchEditFile.ts
+++ b/src/models/commands/fs/VaunchEditFile.ts
@@ -59,7 +59,7 @@ export class VaunchEditFile extends VaunchCommand {
   aliases: string[] = ["edit-file"];
   description = "Edits an existing file";
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     const folders = useFolderStore();
     const fullPath: string = args[0];
     // If fullPath is not defined, no path was passed

--- a/src/models/commands/fs/VaunchMkdir.ts
+++ b/src/models/commands/fs/VaunchMkdir.ts
@@ -27,7 +27,7 @@ export class VaunchMkdir extends VaunchCommand {
   description = "Creates folders";
   aliases: string[] = ["make-folder"];
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     const folder = useFolderStore();
     let existingFolders:string[] = []
     args.forEach((newFolder) => {

--- a/src/models/commands/fs/VaunchMv.ts
+++ b/src/models/commands/fs/VaunchMv.ts
@@ -47,7 +47,7 @@ export class VaunchMv extends VaunchCommand {
   aliases: string[] = ["move", "move-file", "move-folder"];
   description = "Moves or Renames files and folders";
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     if (args.length != 2) {
       return this.makeResponse(ResponseType.Error, "Not enough arguments");
     }

--- a/src/models/commands/fs/VaunchRm.ts
+++ b/src/models/commands/fs/VaunchRm.ts
@@ -35,7 +35,7 @@ export class VaunchRm extends VaunchCommand {
   aliases: string[] = ["remove-file", "delete-file"];
   description = "Deletes files";
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     if (args.length == 0) {
       return this.makeResponse(ResponseType.Error, "Not enough arguments");
     }

--- a/src/models/commands/fs/VaunchRmdir.ts
+++ b/src/models/commands/fs/VaunchRmdir.ts
@@ -46,7 +46,7 @@ export class VaunchRmdir extends VaunchCommand {
 
   aliases: string[] = ["remove-folder", "delete-folder"];
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     if (args.length == 0) {
       return this.makeResponse(ResponseType.Error, "Not enough arguments");
     }

--- a/src/models/commands/fs/VaunchSetDescription.ts
+++ b/src/models/commands/fs/VaunchSetDescription.ts
@@ -36,7 +36,7 @@ export class VaunchSetDescription extends VaunchCommand {
   aliases: string[] = ["set-desc"];
   description = "Sets the description of a file's tooltip";
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     const folders = useFolderStore();
     const fullPath: string | undefined = args.shift();
     if (!fullPath)

--- a/src/models/commands/fs/VaunchSetIcon.ts
+++ b/src/models/commands/fs/VaunchSetIcon.ts
@@ -53,7 +53,7 @@ export class VaunchSetIcon extends VaunchCommand {
   }
   description = "Changes the icon of an existing file/folder";
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     const folders = useFolderStore();
     const fullPath: string = args[0];
     const newIcon: string = args[1];

--- a/src/models/commands/fs/VaunchSetPosition.ts
+++ b/src/models/commands/fs/VaunchSetPosition.ts
@@ -51,7 +51,7 @@ export class VaunchSetPosition extends VaunchCommand {
   description = "Changes file/folder position";
   aliases: string[] = ["set-pos"];
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     const folders = useFolderStore();
     if (args.length < 1) {
       return this.makeResponse(

--- a/src/models/commands/fs/VaunchTouch.ts
+++ b/src/models/commands/fs/VaunchTouch.ts
@@ -54,7 +54,7 @@ export class VaunchTouch extends VaunchCommand {
   aliases: string[] = ["make-file"];
   description = "Creates new files";
 
-  execute(args: string[]): VaunchResponse {
+  async execute(args: string[]): Promise<VaunchResponse> {
     const folders = useFolderStore();
     const newFileName: string = args[0];
 


### PR DESCRIPTION
Setting execute to be an asynchronous method to allow for better use of other asychronous functions like fetch, to properly support await when working with Promises

The main execution response handling in VaunchApp has been changed to use .then() when running execute, while components that invoke commands will await for each command to finish as they often chain internal commands to edit/add files and folders