### PR TITLE
fix:pass credentials when getting/saving dashboard

### DIFF
--- a/src/models/commands/config/VaunchSave.ts
+++ b/src/models/commands/config/VaunchSave.ts
@@ -28,6 +28,7 @@ export class VaunchSave extends VaunchCommand {
     const dashboardPostUrl = new URL('/dashboard', sessionConfig.backendURL).href;
     const response = await fetch(dashboardPostUrl, {
       mode: "cors",
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/stores/folder.ts
+++ b/src/stores/folder.ts
@@ -125,6 +125,7 @@ export const useFolderStore: StoreDefinition = defineStore({
       const sessionConfig = useSessionStore()
       const dashboardIdUrl = new URL('/dashboard/1', sessionConfig.backendURL).href;
       const response = await fetch(dashboardIdUrl, {
+        credentials: "include",
         method: "GET",
         mode: "cors",
       });


### PR DESCRIPTION
Need to set fetch to pass credentials when getting and saving dashboards, which are now protected beind the isAuthenticated middleware