### PR TITLE
fix:use dashboard key when getting a dashboard

### DIFF
--- a/src/stores/folder.ts
+++ b/src/stores/folder.ts
@@ -132,7 +132,7 @@ export const useFolderStore: StoreDefinition = defineStore({
       const dashboard = await response.json();
       if (dashboard) {
         // Load the dashboard data from the remote
-        this.rawFolders = parseDashboard(dashboard['data']);
+        this.rawFolders = parseDashboard(dashboard['dashboard']['data']);
       } else {
         // Dashboard does not exist, blank out the dashboard
         this.rawFolders = new Map<string, VaunchFolder>();


### PR DESCRIPTION
API now responds with ['dashboard'] containing the dashboard data rather than the dashboard keys being at the top level